### PR TITLE
Added correct notation for big numbers on auction page

### DIFF
--- a/src/app/auction-page/auction-page.component.html
+++ b/src/app/auction-page/auction-page.component.html
@@ -111,7 +111,7 @@
         <span class="axn-form-block-pool-title">Auction price</span>
         <div class="axn-form-block-pool-axn">
           <span class="icon icon-flex icon__axion"
-            >{{ poolInfo.axnToEth }} AXN</span
+            >{{ poolInfo.axnToEth | bigNumberFormat: 0:true:false:18 }} AXN</span
           >
           <span class="cl-purple">=</span>
           <span class="icon icon-flex icon__eth-purple cl-purple">1 ETH</span>
@@ -120,7 +120,7 @@
         <span class="axn-form-block-pool-title">Uniswap price</span>
         <div class="axn-form-block-pool-uni">
           <span class="icon icon-flex icon__axion-gray cl-gray-dark"
-            >{{ poolInfo.uniToEth || 0 }} AXN</span
+            >{{ poolInfo.uniToEth | bigNumberFormat: 0:true:false:18 || 0 }} AXN</span
           >
           <span class="cl-gray-dark">=</span>
           <span class="cl-gray-dark">1 ETH</span>


### PR DESCRIPTION
### Currently:
<img width="477" alt="Screenshot 2020-11-14 at 23 34 27" src="https://user-images.githubusercontent.com/1136594/99158338-f4157780-26d1-11eb-98b6-3225163b76d0.png">

### After change:

<img width="477" alt="Screenshot 2020-11-14 at 23 28 31" src="https://user-images.githubusercontent.com/1136594/99158318-b44e9000-26d1-11eb-9f7b-161486d2ea01.png">
