### PR TITLE
Use Math.floor when rounding stake percentage

### DIFF
--- a/src/app/staking-page/staking-page.component.ts
+++ b/src/app/staking-page/staking-page.component.ts
@@ -247,7 +247,7 @@ export class StakingPageComponent implements OnDestroy {
     deposit.oldUpdate = new Date().getTime();
     const fullAge = deposit.end.getTime() - deposit.start.getTime();
     const backAge = new Date().getTime() - deposit.start.getTime();
-    deposit.progress = Math.min(Math.round(backAge / (fullAge / 100)), 100);
+    deposit.progress = Math.min(Math.floor(backAge / (fullAge / 100)), 100);
     return deposit.progress;
   }
 


### PR DESCRIPTION
- Math.round will round stakes at 99.5% complete or greater up to 100%

<details>
<summary>Before</summary>
<img width="348" alt="Screen Shot 2020-11-23 at 3 57 41 PM" src="https://user-images.githubusercontent.com/8884390/100019977-a3bea980-2da4-11eb-86df-ec8fdee6a43d.png">
<img width="865" alt="Screen Shot 2020-11-23 at 3 57 27 PM" src="https://user-images.githubusercontent.com/8884390/100019978-a3bea980-2da4-11eb-8fa8-ccb0e003e01b.png">
</details>


<details>
<summary>After</summary>
<img width="492" alt="Screen Shot 2020-11-23 at 3 56 39 PM" src="https://user-images.githubusercontent.com/8884390/100019931-88ec3500-2da4-11eb-9bba-32188f5e6e0b.png">
<img width="855" alt="Screen Shot 2020-11-23 at 3 56 34 PM" src="https://user-images.githubusercontent.com/8884390/100019932-8984cb80-2da4-11eb-9a49-87487695bbcc.png">
</details>