### PR TITLE
Removed interest from deposit history

### DIFF
--- a/src/app/staking-page/staking-page.component.html
+++ b/src/app/staking-page/staking-page.component.html
@@ -406,7 +406,6 @@
           <th>End date</th>
           <th>Principal</th>
           <th>BigPayDay</th>
-          <th>Interest</th>
         </tr>
       </thead>
       <tbody>
@@ -441,21 +440,6 @@
                 deposit.bigPayDay
                   | bigNumberFormat: tokensDecimals["HEX2X"]:true:false:2
               }}&nbsp;AXN</span
-            >
-          </td>
-          <td>
-            <span
-              matTooltipClass="table__tooltip"
-              mat-raised-button
-              matTooltip="{{
-                deposit.interest
-                  | bigNumberFormat: tokensDecimals['HEX2X']:true:false:18
-              }}"
-            >
-              {{
-                deposit.interest
-                  | bigNumberFormat: tokensDecimals["HEX2X"]:true:false:2
-              }}</span
             >
           </td>
         </tr>


### PR DESCRIPTION
Interest in history is always 0 because shares are set to 0 for that session on unstake