### PR TITLE
Calculate stake progress based on the end of the staking contract day

### DIFF
--- a/src/app/services/contract/index.ts
+++ b/src/app/services/contract/index.ts
@@ -933,11 +933,12 @@ export class ContractService {
             .call()
             .then((startContract) => {
               const stepsFromStart = this.calculateCurrentStepsFromStart(startContract, stepTimestamp);
-              const startOfNextDay = +startContract + (Math.ceil(stepsFromStart) * stepTimestamp)
-              const result = startOfNextDay - 1
+              const startOfNextDay = +startContract + (Math.ceil(stepsFromStart) * stepTimestamp);
+              const startOfNextDayMS = startOfNextDay * 1000
+              const result = startOfNextDayMS - 1;
               return {
                 key: "EndOfContractDay",
-                value: result,
+                value: result < 0 ? 0 : result,
               };
             });
         }),

--- a/src/app/services/contract/index.ts
+++ b/src/app/services/contract/index.ts
@@ -1115,7 +1115,6 @@ export class ContractService {
                             const interest = res;
                             return this.calculateEndOfStakeDay(new Date(oneSession.end * 1000))
                               .then((endOfStake) => {
-                                console.log("EOS: ", endOfStake)
                                 return {
                                   start: new Date(oneSession.start * 1000),
                                   end: endOfStake,

--- a/src/app/staking-page/staking-page.component.ts
+++ b/src/app/staking-page/staking-page.component.ts
@@ -6,17 +6,10 @@ import {
   TemplateRef,
   ViewChild,
 } from "@angular/core";
-import { ContractService, stakingMaxDays } from "../services/contract";
+import { ContractService, StakingInfoInterface, stakingMaxDays } from "../services/contract";
 import BigNumber from "bignumber.js";
 import { AppConfig } from "../appconfig";
 import { MatDialog } from "@angular/material/dialog";
-
-interface StakingInfoInterface {
-  ShareRate: number;
-  StepsFromStart: number;
-  closestYearShares?: string;
-  closestPoolAmount?: string;
-}
 
 const FULL_PERIOD = 700;
 const AVAILABLE_DAYS_AFTER_END = 14;
@@ -226,7 +219,7 @@ export class StakingPageComponent implements OnDestroy {
     this.depositEndDate =
       Date.now() +
       this.formsData.depositDays *
-        this.settingsData.settings.time.seconds *	
+        this.settingsData.settings.time.seconds *
         1000;
 
     const sharefull = new BigNumber(amount).div(
@@ -246,7 +239,7 @@ export class StakingPageComponent implements OnDestroy {
     }
     deposit.oldUpdate = new Date().getTime();
     const fullAge = deposit.end.getTime() - deposit.start.getTime();
-    const backAge = new Date().getTime() - deposit.start.getTime();
+    const backAge = this.stakingContractInfo.EndOfContractDay - deposit.start.getTime();
     deposit.progress = Math.min(Math.floor(backAge / (fullAge / 100)), 100);
     return deposit.progress;
   }

--- a/src/app/staking-page/staking-page.component.ts
+++ b/src/app/staking-page/staking-page.component.ts
@@ -50,6 +50,7 @@ export class StakingPageComponent implements OnDestroy {
   public stakingContractInfo: StakingInfoInterface = {
     ShareRate: 0,
     StepsFromStart: 0,
+    EndOfContractDay: 0,
     closestYearShares: "0",
     closestPoolAmount: "0",
   };

--- a/src/app/staking-page/staking-page.component.ts
+++ b/src/app/staking-page/staking-page.component.ts
@@ -240,7 +240,7 @@ export class StakingPageComponent implements OnDestroy {
     }
     deposit.oldUpdate = new Date().getTime();
     const fullAge = deposit.end.getTime() - deposit.start.getTime();
-    const backAge = this.stakingContractInfo.EndOfContractDay - deposit.start.getTime();
+    const backAge = new Date().getTime() - deposit.start.getTime();
     deposit.progress = Math.min(Math.floor(backAge / (fullAge / 100)), 100);
     return deposit.progress;
   }

--- a/src/app/staking-page/staking-page.component.ts
+++ b/src/app/staking-page/staking-page.component.ts
@@ -6,10 +6,17 @@ import {
   TemplateRef,
   ViewChild,
 } from "@angular/core";
-import { ContractService, StakingInfoInterface, stakingMaxDays } from "../services/contract";
+import { ContractService, stakingMaxDays } from "../services/contract";
 import BigNumber from "bignumber.js";
 import { AppConfig } from "../appconfig";
 import { MatDialog } from "@angular/material/dialog";
+
+interface StakingInfoInterface {
+  ShareRate: number;
+  StepsFromStart: number;
+  closestYearShares?: string;
+  closestPoolAmount?: string;
+}
 
 const FULL_PERIOD = 700;
 const AVAILABLE_DAYS_AFTER_END = 14;
@@ -50,7 +57,6 @@ export class StakingPageComponent implements OnDestroy {
   public stakingContractInfo: StakingInfoInterface = {
     ShareRate: 0,
     StepsFromStart: 0,
-    EndOfContractDay: 0,
     closestYearShares: "0",
     closestPoolAmount: "0",
   };


### PR DESCRIPTION
- Dont show 100% completion until the end of the current contract day so that users dont unstake early and accidentally get a penalty