### PR TITLE
Fix ETH badge changing to the same color as the Axion badge when switching to dark mode

### DIFF
--- a/src/scss/_dark-colors.scss
+++ b/src/scss/_dark-colors.scss
@@ -24,10 +24,10 @@
   }
 
   &-purple {
-    color: $clPurple-dark !important;
+    color: $clPurple !important;
 
     &-bg {
-      background-color: $clPurple-dark !important;
+      background-color: $clPurple !important;
     }
   }
 


### PR DESCRIPTION
Before:
<img width="1302" alt="Screen Shot 2020-11-24 at 8 05 07 PM" src="https://user-images.githubusercontent.com/8884390/100173952-24f36a80-2e91-11eb-96ff-fe7283c3aec7.png">

After:
<img width="1361" alt="Screen Shot 2020-11-24 at 8 07 30 PM" src="https://user-images.githubusercontent.com/8884390/100173948-245ad400-2e91-11eb-95ae-b5946474c4a1.png">
