### PR TITLE
auction status should be complete not withdraw for ngif

### DIFF
--- a/src/app/auction-page/auction-page.component.html
+++ b/src/app/auction-page/auction-page.component.html
@@ -294,7 +294,7 @@
           </td>
           <td class="action-button">
             <button
-              *ngIf="auction.status === 'withdraw'"
+              *ngIf="auction.status === 'complete'"
               class="axn-btn axn-btn-gray"
               style="margin: auto"
               (click)="auctionWithdraw(auction)"


### PR DESCRIPTION
A user was having an issue withdrawing their bid, auction status are "progress" and "complete" not "withdraw" this should show completed auction buttons again.

- Change "withdraw" to "complete"